### PR TITLE
Add PCA9685 to non robot-devices section.

### DIFF
--- a/doc/supported_robots/supported_robots.rst
+++ b/doc/supported_robots/supported_robots.rst
@@ -35,6 +35,7 @@ Non robot-devices:
 * `ODrive Motor Controller <https://github.com/Factor-Robotics/odrive_ros2_control>`_
 * `ODRI Motor Controller <https://github.com/stack-of-tasks/ros2_hardware_interface_odri>`_
 * `NDI measurement systems <https://github.com/ICube-Robotics/ndisys_ros2>`_
+* `PCA9685 16-Channel 12-bit PWM/Servo Driver <https://github.com/rosblox/ros-pca9685-ros2-control>`_
 
 Mobile manipulators:
 

--- a/doc/supported_robots/supported_robots.rst
+++ b/doc/supported_robots/supported_robots.rst
@@ -35,7 +35,7 @@ Non robot-devices:
 * `ODrive Motor Controller <https://github.com/Factor-Robotics/odrive_ros2_control>`_
 * `ODRI Motor Controller <https://github.com/stack-of-tasks/ros2_hardware_interface_odri>`_
 * `NDI measurement systems <https://github.com/ICube-Robotics/ndisys_ros2>`_
-* `PCA9685 16-Channel 12-bit PWM/Servo Driver <https://github.com/rosblox/ros-pca9685-ros2-control>`_
+* `PCA9685 16-Channel 12-bit PWM/Servo Driver <https://github.com/rosblox/pca9685_ros2_control>`_
 
 Mobile manipulators:
 


### PR DESCRIPTION
Adds PCA9685 to non robot-devices section.  

The PCA9685 ros2_control hardware_interface accepts velocity commands.
Velocity commands are clamped to be in the range of -1.0 to 1.0. 
The clamped velocity commands are then translated to PWM commands between 0.5 and 2.5ms. 
The PWM frequency is 50Hz. 